### PR TITLE
Fix purge function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+name: CI
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: ./bin/hermit env --raw >> $GITHUB_ENV
+    - run: go test ./...
+    - run: golangci-lint run

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,35 @@
+package localcache
+
+import "time"
+
+type clocker interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (realClock) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+type fakeClock struct {
+	currentTime time.Time
+}
+
+func (f *fakeClock) Now() time.Time {
+	f.advance(time.Second)
+	return f.currentTime // every time we call now the clock advances a little.
+}
+
+func (f *fakeClock) Since(t time.Time) time.Duration {
+	return f.currentTime.Sub(t)
+}
+
+func (f *fakeClock) advance(d time.Duration) {
+	f.currentTime = f.currentTime.Add(d)
+}


### PR DESCRIPTION
Fix purge function by replacing early return on entry to be purged with
a continue, to ensure all entries that should get purged do get purged.

I wrote to a somewhat elaborate test, mocking time, to avoid brittle behaviour under different execution conditions. The test failed first, before replacing the `return nil` with `continue` in localcache.go.

While at it, add some CI magic for good measure.