### PR TITLE
fix: use MkdirAll to create parent cache directories

### DIFF
--- a/localcache.go
+++ b/localcache.go
@@ -48,7 +48,7 @@ func New(name string) (*Cache, error) {
 		return nil, fmt.Errorf("couldn't locate cache dir: %w", err)
 	}
 	root := filepath.Join(cacheDir, name)
-	err = os.Mkdir(root, 0700)
+	err = os.MkdirAll(root, 0700)
 	if err != nil && !os.IsExist(err) {
 		return nil, fmt.Errorf("couldn't create cache dir: %w", err)
 	}


### PR DESCRIPTION
When the user's cache directory (e.g. `~/.cache`) doesn't exist, `os.Mkdir` fails because it doesn't create parent directories. Use `os.MkdirAll` instead to create the full directory hierarchy.